### PR TITLE
Refactor things into the newly discussed structure

### DIFF
--- a/css/base/_base.css
+++ b/css/base/_base.css
@@ -24,15 +24,21 @@ body {
 }
 
 body {
+	background: #ecf0f1;
 	font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
 }
 
 .wrapper {
-	background-color: #FEFEFE;
 	color: #222222;
+	font-family: monospace;
 	max-width: 978px;
 	margin: 0 auto;
-	padding: 0.5em 0;
+	padding: 1em;
+	white-space: pre-wrap;
+}
+
+body.js-source-code-pro-loaded .wrapper {
+	font-family: 'Source Code Pro', monospace;
 }
 
 .app-name {

--- a/css/components/_verse.css
+++ b/css/components/_verse.css
@@ -1,18 +1,3 @@
-.wrapper {
-	background: #ecf0f1;
-  border-bottom: 1px solid white;
-	display: inline-block;
-	font-family: monospace;
-	margin: 0 0.1em;
-	padding: 1em;
-	white-space: pre-wrap;
-	width: 100%;
-}
-
-body.js-source-code-pro-loaded .wrapper {
-	font-family: 'Source Code Pro', monospace;
-}
-
 .passage-metadata {
 	color: #999;
 	flex-grow: 2;

--- a/css/components/_verse.css
+++ b/css/components/_verse.css
@@ -1,4 +1,4 @@
-.passage-card {
+.wrapper {
 	background: #ecf0f1;
   border-bottom: 1px solid white;
 	display: inline-block;
@@ -9,7 +9,7 @@
 	width: 100%;
 }
 
-body.js-source-code-pro-loaded .passage-card {
+body.js-source-code-pro-loaded .wrapper {
 	font-family: 'Source Code Pro', monospace;
 }
 

--- a/js/actions/AppActions.js
+++ b/js/actions/AppActions.js
@@ -26,7 +26,7 @@
 // Disable the no-use-before-define eslint rule for this file
 // It makes more sense to have the asnyc actions before the non-async ones
 /* eslint-disable no-use-before-define */
-import { NEXT_VERSE, PREVIOUS_VERSE, ENABLE_RECALL, ENABLE_READ, CHANGE_MODE, PLAY_AUDIO, PAUSE_AUDIO } from '../constants/AppConstants';
+import { NEXT_VERSE, PREVIOUS_VERSE, ENABLE_RECALL, ENABLE_READ, CHANGE_MODE, CHANGE_RECALL, PLAY_AUDIO, PAUSE_AUDIO } from '../constants/AppConstants';
 
 export function asyncNextVerse() {
   return (dispatch) => {
@@ -93,28 +93,41 @@ export function changeMode(mode) {
   return { type: CHANGE_MODE, mode };
 }
 
-export function asyncPlayAudio(index) {
+export function asyncChangeRecall(mode) {
   return (dispatch) => {
     // You can do async stuff here!
     // API fetching, Animations,...
     // For more information as to how and why you would do this, check https://github.com/gaearon/redux-thunk
-    return dispatch(playAudio(index));
+    return dispatch(changeRecall(mode));
   }
 }
 
-export function playAudio(index) {
-  return { type: PLAY_AUDIO, index };
+export function changeRecall(mode) {
+  return { type: CHANGE_RECALL, mode };
 }
 
-export function asyncPauseAudio(index) {
+export function asyncPlayAudio() {
   return (dispatch) => {
     // You can do async stuff here!
     // API fetching, Animations,...
     // For more information as to how and why you would do this, check https://github.com/gaearon/redux-thunk
-    return dispatch(pauseAudio(index));
+    return dispatch(playAudio());
   }
 }
 
-export function pauseAudio(index) {
-  return { type: PAUSE_AUDIO, index };
+export function playAudio() {
+  return { type: PLAY_AUDIO };
+}
+
+export function asyncPauseAudio() {
+  return (dispatch) => {
+    // You can do async stuff here!
+    // API fetching, Animations,...
+    // For more information as to how and why you would do this, check https://github.com/gaearon/redux-thunk
+    return dispatch(pauseAudio());
+  }
+}
+
+export function pauseAudio() {
+  return { type: PAUSE_AUDIO };
 }

--- a/js/actions/AppActions.js
+++ b/js/actions/AppActions.js
@@ -26,58 +26,32 @@
 // Disable the no-use-before-define eslint rule for this file
 // It makes more sense to have the asnyc actions before the non-async ones
 /* eslint-disable no-use-before-define */
-import { NEXT_VERSE, PREVIOUS_VERSE, ENABLE_RECALL, ENABLE_READ, CHANGE_MODE, CHANGE_RECALL, PLAY_AUDIO, PAUSE_AUDIO } from '../constants/AppConstants';
+import { NAVIGATE_NEXT, NAVIGATE_PREVIOUS, CHANGE_MODE, CHANGE_RECALL, PLAY_AUDIO, PAUSE_AUDIO } from '../constants/AppConstants';
 
-export function asyncNextVerse() {
+export function asyncNavigateNext() {
   return (dispatch) => {
     // You can do async stuff here!
     // API fetching, Animations,...
     // For more information as to how and why you would do this, check https://github.com/gaearon/redux-thunk
-    return dispatch(nextVerse());
+    return dispatch(navigateNext());
   };
 }
 
-export function nextVerse() {
-  return { type: NEXT_VERSE };
+export function navigateNext() {
+  return { type: NAVIGATE_NEXT };
 }
 
-export function asyncPreviousVerse() {
+export function asyncNavigatePrevious() {
   return (dispatch) => {
     // You can do async stuff here!
     // API fetching, Animations,...
     // For more information as to how and why you would do this, check https://github.com/gaearon/redux-thunk
-    return dispatch(previousVerse());
+    return dispatch(navigatePrevious());
   };
 }
 
-export function previousVerse() {
-  return { type: PREVIOUS_VERSE };
-}
-
-export function asyncEnableRecall(index) {
-  return (dispatch) => {
-    // You can do async stuff here!
-    // API fetching, Animations,...
-    // For more information as to how and why you would do this, check https://github.com/gaearon/redux-thunk
-    return dispatch(enableRecall(index));
-  };
-}
-
-export function enableRecall(index) {
-  return { type: ENABLE_RECALL, index };
-}
-
-export function asyncEnableRead(index) {
-  return (dispatch) => {
-    // You can do async stuff here!
-    // API fetching, Animations,...
-    // For more information as to how and why you would do this, check https://github.com/gaearon/redux-thunk
-    return dispatch(enableRead(index));
-  };
-}
-
-export function enableRead(index) {
-  return { type: ENABLE_READ, index };
+export function navigatePrevious() {
+  return { type: NAVIGATE_PREVIOUS };
 }
 
 export function asyncChangeMode(mode) {

--- a/js/components/AudioPlayer.react.js
+++ b/js/components/AudioPlayer.react.js
@@ -8,12 +8,12 @@ import { asyncPlayAudio, asyncPauseAudio } from '../actions/AppActions';
 
 class AudioPlayer extends Component {
   render() {
-    const { dispatch, src, isAudioPlaying, index } = this.props;
+    const { dispatch, src, isAudioPlaying } = this.props;
 
     if (isAudioPlaying) {
       return (
         <span className="audioContainer">
-          <li className="pauseAudio" onClick={() => {dispatch(asyncPauseAudio(index))} }>
+          <li className="pauseAudio" onClick={() => {dispatch(asyncPauseAudio())} }>
             <i className="fa fa-pause" title="pause"></i>
           </li>
           <audio src={ src } autoPlay="autoPlay" loop="loop"/>
@@ -22,7 +22,7 @@ class AudioPlayer extends Component {
     } else {
       return (
         <span className="audioContainer">
-          <li className="playAudio" onClick={() => {dispatch(asyncPlayAudio(index))} }>
+          <li className="playAudio" onClick={() => {dispatch(asyncPlayAudio())} }>
             <i className="fa fa-play" title="play"></i>
           </li>
         </span>

--- a/js/components/Verse.react.js
+++ b/js/components/Verse.react.js
@@ -25,12 +25,12 @@ class Verse extends Component {
         // the eventual fourth recall stage for random words would live here
 
         case RECALL_STAGES.NONE:
-          return '';
+          return text.replace(/./g, ' ');
       }
     }
 
     return (
-      <span>
+      <span className="verse-wrapper">
         <span className="verse-number">
           <strong>{ verse }</strong>
         </span>

--- a/js/components/Verse.react.js
+++ b/js/components/Verse.react.js
@@ -1,52 +1,44 @@
 /*
  * Verse
  */
-
-import { asyncEnableRecall, asyncEnableRead, asyncPlayAudio, asyncPauseAudio, asyncNextVerse, asyncPreviousVerse } from '../actions/AppActions';
-import { VERSE_STATES } from '../constants/AppConstants';
+import { RECALL_STAGES } from '../constants/AppConstants';
 
 import React, { Component } from 'react';
-import AudioPlayer from './AudioPlayer.react';
-import Swipeable from 'react-swipeable';
 
 class Verse extends Component {
   render() {
-    const { index, book, chapter, text, verse, isAudioPlaying, verseState, dispatch } = this.props;
-    const verseMeta = book + ' ' + chapter + ':' + verse;
+    const { verse, text, recallStage } = this.props;
 
-    const audioUrl = "http://www.esvapi.org/v2/rest/passageQuery?key=IP&passage=" +
-      encodeURI(verseMeta) + "&output-format=mp3";
+    /**
+     * Render the text to the verse based on the recall mode.
+     */
+    function renderText(text) {
+      switch(recallStage) {
+        case RECALL_STAGES.FULL:
+          return text;
 
-    function splitText(text) {
-      return text.split(' ').map(function (word) {
-        return word[0] + word.slice(1, word.length).replace(/\w/g, ' ');
-      }).join(' ');
+        case RECALL_STAGES.FIRST:
+          return text.split(' ').map(function (word) {
+            return word[0] + word.slice(1, word.length).replace(/\w/g, ' ');
+          }).join(' ');
+
+        // the eventual fourth recall stage for random words would live here
+
+        case RECALL_STAGES.NONE:
+          return '';
+      }
     }
 
     return (
-      <Swipeable
-        className="passage-card"
-        onSwipedLeft={() => { dispatch(asyncNextVerse()) }}
-        onSwipedRight={() => { dispatch(asyncPreviousVerse()) }}
-      >
-        <p className="passage-metadata">{ verseMeta }</p>
-        <p className="passage-text">{ verseState == VERSE_STATES.RECALL ? splitText(text) : text }</p>
+      <span>
+        <span className="verse-number">
+          <strong>{ verse }</strong>
+        </span>
 
-        <ol className="passage-states">
-          <li
-            className={ verseState == VERSE_STATES.READ ? "active" : ""}
-            onClick={() => { dispatch(asyncEnableRead(index)) }}
-          >Know</li>
-          <li
-            className={ verseState == VERSE_STATES.RECALL ? "active" : ""}
-            onClick={() => { dispatch(asyncEnableRecall(index)) }}
-          >K___</li>
-          <AudioPlayer src={ audioUrl }
-                       dispatch={ dispatch }
-                       isAudioPlaying={ isAudioPlaying }
-                       index={ index } />
-        </ol>
-      </Swipeable>
+        <span className="verse-text">
+          { renderText(text) }
+        </span>
+      </span>
     );
   }
 }

--- a/js/components/pages/PassagePage.react.js
+++ b/js/components/pages/PassagePage.react.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
-import { asyncNextVerse, asyncPreviousVerse, asyncChangeMode, asyncChangeRecall } from '../../actions/AppActions';
+import { asyncNavigateNext, asyncNavigatePrevious, asyncChangeMode, asyncChangeRecall } from '../../actions/AppActions';
 import { VERSE_MODE, SEGMENT_MODE, CHAPTER_MODE, RECALL_STAGES } from '../../constants/AppConstants';
 
 import Verse from '../Verse.react';
@@ -140,22 +140,22 @@ export class PassagePage extends Component {
           <button className="previous"
                   title="Previous"
                   disabled="{ canNavigatePrevious() }"
-                  onClick={() => { dispatch(asyncPreviousVerse()) }}>
+                  onClick={() => { dispatch(asyncNavigatePrevious()) }}>
             Previous
           </button>
 
           <button className="next"
                   title="Next"
                   disabled="{ canNavigateNext() }"
-                  onClick={() => { dispatch(asyncNextVerse()) }}>
+                  onClick={() => { dispatch(asyncNavigateNext()) }}>
             Next
           </button>
         </div>
 
         <Swipeable
           className="verse-wrapper"
-          onSwipedLeft={() => { dispatch(asyncNextVerse()) }}
-          onSwipedRight={() => { dispatch(asyncPreviousVerse()) }}>
+          onSwipedLeft={() => { dispatch(asyncNavigateNext()) }}
+          onSwipedRight={() => { dispatch(asyncNavigatePrevious()) }}>
 
           { renderedVerses }
         </Swipeable>

--- a/js/components/pages/PassagePage.react.js
+++ b/js/components/pages/PassagePage.react.js
@@ -26,18 +26,18 @@ export class PassagePage extends Component {
      * @return boolean Whether or not we can navigate backward
      */
     function canNavigatePrevious() {
-      return activeVerse > 0;
+      return true;
     }
 
     /**
      * Take into account the current mode, and determine if we can navigation backward.
      *
-     * @TODO make this better than a simple index check (which is only good for verse mode)
+     * @TODO make this work.
      *
      * @return boolean Whether or not we can navigate forward
      */
     function canNavigateNext() {
-      return activeVerse < verses.length - 1;
+      return true;
     }
 
     /**
@@ -105,9 +105,13 @@ export class PassagePage extends Component {
              assembleMeta(assembleMeta()) + '&output-format=mp3';
     }
 
-    let renderedVerses = ''
+    function renderVerses() {
+      let renderedVerses = '';
 
-    if (verses) {
+      if (!verses) {
+        return;
+      }
+
       renderedVerses = verses.map(function(verse, index) {
         if (index < lowerBound || index > upperBound) {
           return '';
@@ -120,16 +124,18 @@ export class PassagePage extends Component {
                  recallStage={ recallStage } />
         );
       });
+
+      return renderedVerses;
     }
 
     return (
       <div>
         <div className="mode-controls">
-          <button className="scripture-mode" onClick={() => { dispatch(asyncChangeMode(VERSE_MODE)) }}>'Single verse'</button>
+          <button className="scripture-mode" onClick={() => { dispatch(asyncChangeMode(VERSE_MODE)) }}>Single verse</button>
 
-          <button className="scripture-mode" onClick={() => { dispatch(asyncChangeMode(SEGMENT_MODE)) }}>'Group of verses'</button>
+          <button className="scripture-mode" onClick={() => { dispatch(asyncChangeMode(SEGMENT_MODE)) }}>Group of verses</button>
 
-          <button className="scripture-mode" onClick={() => { dispatch(asyncChangeMode(CHAPTER_MODE)) }}>'Full chapter'</button>
+          <button className="scripture-mode" onClick={() => { dispatch(asyncChangeMode(CHAPTER_MODE)) }}>Full chapter</button>
         </div>
 
         <div className="meta-information">
@@ -139,14 +145,14 @@ export class PassagePage extends Component {
         <div className="verse-controls">
           <button className="previous"
                   title="Previous"
-                  disabled="{ canNavigatePrevious() }"
+                  disabled={ !canNavigatePrevious() }
                   onClick={() => { dispatch(asyncNavigatePrevious()) }}>
             Previous
           </button>
 
           <button className="next"
                   title="Next"
-                  disabled="{ canNavigateNext() }"
+                  disabled={ !canNavigateNext() }
                   onClick={() => { dispatch(asyncNavigateNext()) }}>
             Next
           </button>
@@ -157,7 +163,7 @@ export class PassagePage extends Component {
           onSwipedLeft={() => { dispatch(asyncNavigateNext()) }}
           onSwipedRight={() => { dispatch(asyncNavigatePrevious()) }}>
 
-          { renderedVerses }
+          { renderVerses() }
         </Swipeable>
 
         <div className="stage-controls">

--- a/js/components/pages/PassagePage.react.js
+++ b/js/components/pages/PassagePage.react.js
@@ -46,12 +46,12 @@ export class PassagePage extends Component {
           return '';
         }
 
-        return <span key={ index }>
-                 <span className="verse-number">
-                   <strong>{ verse.verse }</strong>
-                 </span>
-                 <span className="verse-text">{ verse.text }</span>
-               </span>;
+        return (
+          <Verse key={ index }
+                 verse={ verse.verse }
+                 text={ verse.text }
+                 recallStage={ recallStage } />
+        );
       });
     }
 

--- a/js/components/pages/PassagePage.react.js
+++ b/js/components/pages/PassagePage.react.js
@@ -38,6 +38,71 @@ export class PassagePage extends Component {
       return activeVerse < verses.length - 1;
     }
 
+    /**
+     * Take the current range of verses and generate meta information.
+     *
+     * @return string A string of verse meta information
+     */
+    function assembleMeta() {
+      let meta = '';
+
+      if (!verses || typeof lowerBound === 'undefined' || typeof upperBound === 'undefined') {
+        return;
+      }
+
+      let lower = verses[lowerBound];
+
+      // assemble the information for the lower bound
+      meta += lower.book + ' ' + lower.chapter + ':' + lower.verse;
+
+      // no need to continue if upper and lower are the same
+      if (lowerBound === upperBound) {
+        return meta;
+      }
+
+      let upper = verses[upperBound];
+
+      // fill in the appropriate information for the upper bound
+      // meaning we don't want to duplicate the same book
+      // or the same chapter
+      let bookTriggered = false,
+          onlyVerse     = true;
+
+      if (upper.book !== lower.book) {
+        meta += ' - ' + upper.book + ' ';
+
+        bookTriggered = true;
+      }
+
+      if (bookTriggered || upper.chapter !== lower.chapter) {
+        if (!bookTriggered) {
+          meta += ' - ';
+        }
+
+        meta += upper.chapter + ':';
+
+        onlyVerse = false;
+      }
+
+      if (onlyVerse) {
+        meta += '-';
+      }
+
+      meta += upper.verse;
+
+      return meta;
+    }
+
+    /**
+     * URL encode a string that can be used to get audio from the Crossway API.
+     *
+     * @return string The mp3 request string
+     */
+    function audioURL() {
+      return 'http://www.esvapi.org/v2/rest/passageQuery?key=IP&passage=' +
+             assembleMeta(assembleMeta()) + '&output-format=mp3';
+    }
+
     let renderedVerses = ''
 
     if (verses) {
@@ -63,6 +128,10 @@ export class PassagePage extends Component {
           <button className="scripture-mode" onClick={() => { dispatch(asyncChangeMode(SEGMENT_MODE)) }}>'Group of verses'</button>
 
           <button className="scripture-mode" onClick={() => { dispatch(asyncChangeMode(CHAPTER_MODE)) }}>'Full chapter'</button>
+        </div>
+
+        <div className="meta-information">
+          { assembleMeta() }
         </div>
 
         <div className="verse-controls">

--- a/js/components/pages/PassagePage.react.js
+++ b/js/components/pages/PassagePage.react.js
@@ -5,16 +5,18 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
-import { asyncNextVerse, asyncPreviousVerse, asyncChangeMode } from '../../actions/AppActions';
-import { VERSE_MODE, SEGMENT_MODE, CHAPTER_MODE } from '../../constants/AppConstants';
+import { asyncNextVerse, asyncPreviousVerse, asyncChangeMode, asyncChangeRecall } from '../../actions/AppActions';
+import { VERSE_MODE, SEGMENT_MODE, CHAPTER_MODE, RECALL_STAGES } from '../../constants/AppConstants';
 
 import Verse from '../Verse.react';
+import AudioPlayer from '../AudioPlayer.react';
+import Swipeable from 'react-swipeable';
 
 // use named export for unconnected component (unit tests)
 export class PassagePage extends Component {
   render() {
     const dispatch = this.props.dispatch;
-    const { active, lowerBound, upperBound, verses, mode, recallStage } = this.props.data;
+    const { active, lowerBound, upperBound, verses, mode, recallStage, isAudioPlaying } = this.props.data;
 
     /**
      * Take into account the current mode, and determine if we can navigation backward.
@@ -150,9 +152,26 @@ export class PassagePage extends Component {
           </button>
         </div>
 
-        <div className="verse-wrapper">
+        <Swipeable
+          className="verse-wrapper"
+          onSwipedLeft={() => { dispatch(asyncNextVerse()) }}
+          onSwipedRight={() => { dispatch(asyncPreviousVerse()) }}>
+
           { renderedVerses }
+        </Swipeable>
+
+        <div className="stage-controls">
+          <button className="recall-stage" onClick={() => { dispatch(asyncChangeRecall(RECALL_STAGES.FULL)) }}>Know</button>
+
+          <button className="recall-stage" onClick={() => { dispatch(asyncChangeRecall(RECALL_STAGES.FIRST)) }}>K___</button>
+
+          <button className="recall-stage" onClick={() => { dispatch(asyncChangeRecall(RECALL_STAGES.NONE)) }}>____</button>
         </div>
+
+        <AudioPlayer className="audio-controls"
+                     src={ audioURL() }
+                     dispatch={ dispatch }
+                     isAudioPlaying={ isAudioPlaying } />
 
         <p><a href="http://www.esv.org" className="copyright">ESV</a></p>
       </div>

--- a/js/constants/AppConstants.js
+++ b/js/constants/AppConstants.js
@@ -19,6 +19,7 @@ export const VERSE_MODE   = 'VERSE_MODE';
 export const SEGMENT_MODE = 'SEGMENT_MODE';
 export const CHAPTER_MODE = 'CHAPTER_MODE';
 
+export const CHANGE_RECALL = 'CHANGE_RECALL';
 export const RECALL_STAGES = {
   FULL : 'FULL',
   FIRST: 'FIRST',

--- a/js/constants/AppConstants.js
+++ b/js/constants/AppConstants.js
@@ -9,22 +9,18 @@
 export const NEXT_VERSE     = 'NEXT_VERSE';
 export const PREVIOUS_VERSE = 'PREVIOUS_VERSE';
 export const ENABLE_RECALL  = 'ENABLE_RECALL';
-export const ENABLE_READ = 'ENABLE_READ';
+export const ENABLE_READ    = 'ENABLE_READ';
 export const CHANGE_MODE    = 'CHANGE_MODE';
 
 export const PLAY_AUDIO  = 'PLAY_AUDIO';
 export const PAUSE_AUDIO = 'PAUSE_AUDIO';
 
-export const SINGLE_MODE = 'SINGLE_MODE';
-export const MULTI_MODE  = 'MULTI_MODE';
+export const VERSE_MODE   = 'VERSE_MODE';
+export const SEGMENT_MODE = 'SEGMENT_MODE';
+export const CHAPTER_MODE = 'CHAPTER_MODE';
 
-// these could eventually be repalced with translation strings
-export const MODES = {
-  SINGLE_MODE : 'Single scripture mode',
-  MULTI_MODE  : 'Multi scripture mode'
-}
-
-export const VERSE_STATES = {
-  READ : 'Reading passage',
-  RECALL : 'Assisted Recall'
-}
+export const RECALL_STAGES = {
+  FULL : 'FULL',
+  FIRST: 'FIRST',
+  NONE : 'NONE'
+};

--- a/js/constants/AppConstants.js
+++ b/js/constants/AppConstants.js
@@ -6,15 +6,13 @@
  * Follow this format:
  * export const YOUR_ACTION_CONSTANT = 'YOUR_ACTION_CONSTANT';
  */
-export const NEXT_VERSE     = 'NEXT_VERSE';
-export const PREVIOUS_VERSE = 'PREVIOUS_VERSE';
-export const ENABLE_RECALL  = 'ENABLE_RECALL';
-export const ENABLE_READ    = 'ENABLE_READ';
-export const CHANGE_MODE    = 'CHANGE_MODE';
+export const NAVIGATE_PREVIOUS = 'NAVIGATE_PREVIOUS';
+export const NAVIGATE_NEXT     = 'NAVIGATE_NEXT';
 
 export const PLAY_AUDIO  = 'PLAY_AUDIO';
 export const PAUSE_AUDIO = 'PAUSE_AUDIO';
 
+export const CHANGE_MODE  = 'CHANGE_MODE';
 export const VERSE_MODE   = 'VERSE_MODE';
 export const SEGMENT_MODE = 'SEGMENT_MODE';
 export const CHAPTER_MODE = 'CHAPTER_MODE';

--- a/js/passage.js
+++ b/js/passage.js
@@ -402,9 +402,23 @@ export function verses() {
   return passage;
 }
 
+let _staticSegments = [];
+
+export function staticSegments() {
+  if (!_staticSegments) {
+    segments();
+  }
+
+  return _staticSegments;
+}
+
 // this is a temporary random sorting sorting into segments,
 // just to get something in place
 export function segments() {
+  if (_staticSegments.length) {
+    return _staticSegments;
+  }
+
   let segments = [];
 
   for (let i = 0, lengthI = passage.length; i < lengthI; i++) {
@@ -426,7 +440,9 @@ export function segments() {
     segments[segments.length] = newSegment;
   }
 
-  return segments;
+  _staticSegments = segments;
+
+  return _staticSegments;
 }
 
 export function chapters() {

--- a/js/passage.js
+++ b/js/passage.js
@@ -401,3 +401,52 @@ const passage = Object.freeze([
 export function verses() {
   return passage;
 }
+
+// this is a temporary random sorting sorting into segments,
+// just to get something in place
+export function segments() {
+  let segments = [];
+
+  for (let i = 0, lengthI = passage.length; i < lengthI; i++) {
+    let newSegment = {
+      lower: i
+    };
+
+    let length = Math.floor(Math.random() * (5 - 2 + 1)) + 2;
+
+    i += length;
+
+    // make sure the upper bound is valid
+    if (!passage[i]) {
+      newSegment.upper = passage.length - 1;
+    } else {
+      newSegment.upper = i;
+    }
+
+    segments[segments.length] = newSegment;
+  }
+
+  return segments;
+}
+
+export function chapters() {
+  let chapters = {};
+
+  for (let i in passage) {
+    let currentVerse = passage[i];
+
+    // if this is the first verse in the chapter, assign the lower bound
+    if (!chapters[currentVerse.chapter]) {
+      chapters[currentVerse.chapter] = {
+        lower: parseInt(i)
+      };
+    }
+
+    // if this is the last verse in a chapter, assign the upper bound
+    if (!passage[i + 1] || passage[i + 1].chapter !== currentVerse.chapter) {
+      chapters[currentVerse.chapter].upper = parseInt(i);
+    }
+  }
+
+  return chapters;
+}

--- a/js/reducers/passageReducer.js
+++ b/js/reducers/passageReducer.js
@@ -56,11 +56,12 @@ const initialState = assignToEmpty({
     'SEGMENT_MODE': 0,
     'CHAPTER_MODE': '1'
   },
-  lowerBound : segments[0].lower,
-  upperBound : segments[0].upper,
-  verses     : verses,
-  mode       : SEGMENT_MODE,
-  recallStage: RECALL_STAGES.FULL
+  lowerBound    : segments[0].lower,
+  upperBound    : segments[0].upper,
+  verses        : verses,
+  mode          : SEGMENT_MODE,
+  recallStage   : RECALL_STAGES.FULL,
+  isAudioPlaying: false
 });
 
 function passageReducer(state = initialState, action) {

--- a/js/reducers/passageReducer.js
+++ b/js/reducers/passageReducer.js
@@ -32,8 +32,8 @@ const chapters = passage.chapters();
  * This will also need smarts to set the bounds when navigating between modes.
  */
 function setBounds(mode, active) {
-  let lower = 0,
-      upper = 0;
+  let lower,
+      upper;
 
   switch (mode) {
     case VERSE_MODE:
@@ -75,33 +75,30 @@ function passageReducer(state = initialState, action) {
   Object.freeze(state); // Don't mutate state directly, always use assign()!
 
   let newActive = {},
-      newLower,
-      newUpper;
+      newBounds;
 
   switch (action.type) {
     case NAVIGATE_NEXT:
-      newLower = state.lowerBound + 1;
-      newUpper = state.upperBound + 1;
-
       newActive = state.active;
       newActive[state.mode]++;
 
+      newBounds = setBounds(state.mode, newActive);
+
       return assignToEmpty(state, {
-        lowerBound : newLower,
-        upperBound : newUpper,
+        lowerBound : newBounds.lower,
+        upperBound : newBounds.upper,
         active     : newActive
       });
 
     case NAVIGATE_PREVIOUS:
-      newLower = state.lowerBound - 1;
-      newUpper = state.upperBound - 1;
-
       newActive = state.active;
       newActive[state.mode]--;
 
+      newBounds = setBounds(state.mode, newActive);
+
       return assignToEmpty(state, {
-        lowerBound : newLower,
-        upperBound : newUpper,
+        lowerBound : newBounds.lower,
+        upperBound : newBounds.upper,
         active     : newActive
       });
 
@@ -111,7 +108,7 @@ function passageReducer(state = initialState, action) {
       });
 
     case CHANGE_MODE:
-      let newBounds = setBounds(action.mode, state.active);
+      newBounds = setBounds(action.mode, state.active);
 
       return assignToEmpty(state, {
         lowerBound : newBounds.lower,

--- a/test/component.passage.test.js
+++ b/test/component.passage.test.js
@@ -9,7 +9,7 @@ import { PassagePage } from '../js/components/pages/PassagePage.react';
 describe('PassagePage', () => {
   let React, TestUtils, getInstance;
 
-  before(() => {
+  beforeEach(() => {
     jsdomify.create();
 
     React     = require('react');
@@ -22,7 +22,7 @@ describe('PassagePage', () => {
     };
   });
 
-  after(() => {
+  afterEach(() => {
     jsdomify.destroy();
   });
 
@@ -32,7 +32,7 @@ describe('PassagePage', () => {
     expect(element).toBeTruthy();
   });
 
-  describe('changing modes', function() {
+  describe('changing modes', () => {
     let verses = passage.verses(),
         props  = {
           active: {
@@ -43,7 +43,7 @@ describe('PassagePage', () => {
           verses: verses
         };
 
-    after(() => {
+    afterEach(() => {
       props.mode = null
     });
 
@@ -85,13 +85,13 @@ describe('PassagePage', () => {
     });
   });
 
-  describe('rendering meta', function() {
+  describe('rendering meta', () => {
     let verses = passage.verses(),
         props  = {
           verses: verses
         };
 
-    after(() => {
+    afterEach(() => {
       props.verses = verses;
     });
 

--- a/test/component.passage.test.js
+++ b/test/component.passage.test.js
@@ -83,5 +83,100 @@ describe('PassagePage', () => {
 
       expect(renderedVerses.length).toEqual(props.upperBound - props.lowerBound + 1);
     });
-  })
+  });
+
+  describe('rendering meta', function() {
+    let verses = passage.verses(),
+        props  = {
+          verses: verses
+        };
+
+    after(() => {
+      props.verses = verses;
+    });
+
+    it('should render the meta information on a single verse', () => {
+      props.lowerBound = 0;
+      props.upperBound = 0;
+
+      let element  = getInstance(props);
+      let metaInfo = TestUtils.findRenderedDOMComponentWithClass(element, 'meta-information');
+
+      var expectedMeta = verses[props.lowerBound].book + ' ' +
+                         verses[props.lowerBound].chapter + ':' +
+                         verses[props.lowerBound].verse;
+
+      expect(metaInfo.textContent).toEqual(expectedMeta);
+    });
+
+    it('should render the meta information on verses in the same chapter and book', () => {
+      props.lowerBound = 0;
+      props.upperBound = 1;
+
+      let element  = getInstance(props);
+      let metaInfo = TestUtils.findRenderedDOMComponentWithClass(element, 'meta-information');
+
+      var expectedMeta = verses[props.lowerBound].book + ' ' +
+                         verses[props.lowerBound].chapter + ':' +
+                         verses[props.lowerBound].verse + '-' +
+                         verses[props.upperBound].verse;
+
+      expect(metaInfo.textContent).toEqual(expectedMeta);
+    });
+
+    it('should render the meta information on verses in two different books', () => {
+      let newVerses = [{
+          "book": "First",
+          "chapter": 1,
+          "verse": 1,
+      }, {
+          "book": "Second",
+          "chapter": 1,
+          "verse": 2,
+      }];
+
+      props.verses     = newVerses;
+      props.lowerBound = 0;
+      props.upperBound = 1;
+
+      let element  = getInstance(props);
+      let metaInfo = TestUtils.findRenderedDOMComponentWithClass(element, 'meta-information');
+
+      var expectedMeta = newVerses[props.lowerBound].book + ' ' +
+                         newVerses[props.lowerBound].chapter + ':' +
+                         newVerses[props.lowerBound].verse + ' - ' +
+                         newVerses[props.upperBound].book + ' ' +
+                         newVerses[props.upperBound].chapter + ':' +
+                         newVerses[props.upperBound].verse;
+
+      expect(metaInfo.textContent).toEqual(expectedMeta);
+    });
+
+    it('should render the meta information on verses in two different chapters', () => {
+      let newVerses = [{
+          "book": "First",
+          "chapter": 1,
+          "verse": 1,
+      }, {
+          "book": "First",
+          "chapter": 2,
+          "verse": 2,
+      }];
+
+      props.verses     = newVerses;
+      props.lowerBound = 0;
+      props.upperBound = 1;
+
+      let element  = getInstance(props);
+      let metaInfo = TestUtils.findRenderedDOMComponentWithClass(element, 'meta-information');
+
+      var expectedMeta = newVerses[props.lowerBound].book + ' ' +
+                         newVerses[props.lowerBound].chapter + ':' +
+                         newVerses[props.lowerBound].verse + ' - ' +
+                         newVerses[props.upperBound].chapter + ':' +
+                         newVerses[props.upperBound].verse;
+
+      expect(metaInfo.textContent).toEqual(expectedMeta);
+    });
+  });
 });

--- a/test/component.passage.test.js
+++ b/test/component.passage.test.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import jsdomify from 'jsdomify';
 
-import { MODES, SINGLE_MODE, MULTI_MODE } from '../js/constants/AppConstants';
+import { VERSE_MODE, SEGMENT_MODE, CHAPTER_MODE } from '../js/constants/AppConstants';
 import * as passage from '../js/passage';
 
 import { PassagePage } from '../js/components/pages/PassagePage.react';
@@ -35,43 +35,53 @@ describe('PassagePage', () => {
   describe('changing modes', function() {
     let verses = passage.verses(),
         props  = {
-          activeVerse: 0,
-          totalVerses: verses.length,
-          verses     : verses
+          active: {
+            'VERSE_MODE'  : 0,
+            'SEGMENT_MODE': 0,
+            'CHAPTER_MODE': '1'
+          },
+          verses: verses
         };
 
     after(() => {
       props.mode = null
     });
 
-    it('should assign the correct button text based on mode', () => {
-      let element     = getInstance({ mode: SINGLE_MODE });
-      let modeElement = TestUtils.findRenderedDOMComponentWithClass(element, 'scripture-mode');
-
-      expect(modeElement.textContent).toEqual(MODES[MULTI_MODE]);
-
-      element     = getInstance({ mode: MULTI_MODE });
-      modeElement = TestUtils.findRenderedDOMComponentWithClass(element, 'scripture-mode');
-
-      expect(modeElement.textContent).toEqual(MODES[SINGLE_MODE]);
-    });
-
     it('should render the active verse in single mode', () => {
-      props.mode = SINGLE_MODE;
+      props.mode       = VERSE_MODE;
+      props.lowerBound = 0;
+      props.upperBound = 0;
 
-      let element      = getInstance(props);
-      let passageCards = TestUtils.scryRenderedDOMComponentsWithClass(element, 'passage-card');
+      let element        = getInstance(props);
+      let renderedVerses = TestUtils.scryRenderedDOMComponentsWithClass(element, 'verse-number');
 
-      expect(passageCards.length).toEqual(1);
+      expect(renderedVerses.length).toEqual(1);
     });
 
-    it('should render all verses in multi mode', () => {
-      props.mode = MULTI_MODE;
+    it('should render all verses for a segment in segment mode', () => {
+      let segments = passage.segments();
 
-      let element      = getInstance(props);
-      let passageCards = TestUtils.scryRenderedDOMComponentsWithClass(element, 'passage-card');
+      props.mode       = SEGMENT_MODE;
+      props.lowerBound = segments[props.active[props.mode]].lower;
+      props.upperBound = segments[props.active[props.mode]].upper;
 
-      expect(passageCards.length).toEqual(props.totalVerses);
+      let element        = getInstance(props);
+      let renderedVerses = TestUtils.scryRenderedDOMComponentsWithClass(element, 'verse-number');
+
+      expect(renderedVerses.length).toEqual(props.upperBound - props.lowerBound + 1);
+    });
+
+    it('should render all verses for a chapter in chapter mode', () => {
+      let chapters = passage.chapters();
+
+      props.mode       = CHAPTER_MODE;
+      props.lowerBound = chapters[props.active[props.mode]].lower;
+      props.upperBound = chapters[props.active[props.mode]].upper;
+
+      let element        = getInstance(props);
+      let renderedVerses = TestUtils.scryRenderedDOMComponentsWithClass(element, 'verse-number');
+
+      expect(renderedVerses.length).toEqual(props.upperBound - props.lowerBound + 1);
     });
   })
 });

--- a/test/component.verse.test.js
+++ b/test/component.verse.test.js
@@ -81,6 +81,13 @@ describe('Verse', () => {
       'A capital Letter'
     ];
 
+    let expectedStrings = [
+      '   ',
+      '         ',
+      '           ',
+      '                '
+    ];
+
     verse.recallStage = RECALL_STAGES.NONE;
 
     for (let i in sampleStrings) {
@@ -89,7 +96,7 @@ describe('Verse', () => {
       let element     = getInstance(verse);
       let textElement = TestUtils.findRenderedDOMComponentWithClass(element, 'verse-text');
 
-      expect(textElement.textContent).toBeFalsy();
+      expect(textElement.textContent).toEqual(expectedStrings[i]);
     }
   });
 });

--- a/test/component.verse.test.js
+++ b/test/component.verse.test.js
@@ -2,9 +2,9 @@ import expect from 'expect';
 import jsdomify from 'jsdomify';
 
 import * as passage from '../js/passage';
+import { RECALL_STAGES } from '../js/constants/AppConstants';
 
 import Verse from '../js/components/Verse.react';
-import { VERSE_STATES } from '../js/constants/AppConstants';
 
 describe('Verse', () => {
   let React, TestUtils, getInstance;
@@ -34,16 +34,19 @@ describe('Verse', () => {
     expect(element).toBeTruthy();
   });
 
-  it('should render the correct information from the provided verse', () => {
-    let element     = getInstance(verse);
-    let metaElement = TestUtils.findRenderedDOMComponentWithClass(element, 'passage-metadata');
-    let textElement = TestUtils.findRenderedDOMComponentWithClass(element, 'passage-text');
+  it('should render the correct information from the provided verse in FULL recall', () => {
+    verse.recallStage = RECALL_STAGES.FULL;
 
-    expect(metaElement.textContent).toEqual(verse.book + ' ' + verse.chapter + ':' + verse.verse);
+    let element      = getInstance(verse);
+    let verseElement = TestUtils.findRenderedDOMComponentWithClass(element, 'verse-number');
+    let textElement  = TestUtils.findRenderedDOMComponentWithClass(element, 'verse-text');
+
+    // not sure why toEqual wasn't loose type checking like it should, but it wasn't
+    expect(verseElement.textContent).toEqual(verse.verse.toString());
     expect(textElement.textContent).toEqual(verse.text);
   });
 
-  it('should split the display text (leaving capitals and spacing) when in recall mode', () => {
+  it('should split the display text (leaving capitals and spacing) when in FIRST recall', () => {
     let sampleStrings = [
       'one',
       'two words',
@@ -58,15 +61,35 @@ describe('Verse', () => {
       'A c       L     '
     ];
 
-    verse.verseState = VERSE_STATES.RECALL;
+    verse.recallStage = RECALL_STAGES.FIRST;
 
     for (let i in sampleStrings) {
       verse.text = sampleStrings[i];
 
       let element     = getInstance(verse);
-      let textElement = TestUtils.findRenderedDOMComponentWithClass(element, 'passage-text');
+      let textElement = TestUtils.findRenderedDOMComponentWithClass(element, 'verse-text');
 
       expect(textElement.textContent).toEqual(expectedStrings[i]);
+    }
+  });
+
+  it('should display no text when in NONE recall', () => {
+    let sampleStrings = [
+      'one',
+      'two words',
+      'three words',
+      'A capital Letter'
+    ];
+
+    verse.recallStage = RECALL_STAGES.NONE;
+
+    for (let i in sampleStrings) {
+      verse.text = sampleStrings[i];
+
+      let element     = getInstance(verse);
+      let textElement = TestUtils.findRenderedDOMComponentWithClass(element, 'verse-text');
+
+      expect(textElement.textContent).toBeFalsy();
     }
   });
 });

--- a/test/component.verse.test.js
+++ b/test/component.verse.test.js
@@ -11,7 +11,7 @@ describe('Verse', () => {
 
   let verse = passage.verses()[0];
 
-  before(() => {
+  beforeEach(() => {
     jsdomify.create();
 
     React     = require('react');
@@ -24,7 +24,7 @@ describe('Verse', () => {
     };
   });
 
-  after(() => {
+  afterEach(() => {
     jsdomify.destroy();
   });
 

--- a/test/reducer.passage.test.js
+++ b/test/reducer.passage.test.js
@@ -4,131 +4,258 @@ import * as constants from '../js/constants/AppConstants';
 import * as passage from '../js/passage'
 
 import passageReducer from '../js/reducers/passageReducer';
-import { VERSE_STATES } from '../js/constants/AppConstants';
 
 describe('passageReducer', () => {
   it('should return the initial state', () => {
-    const verses = passage.verses();
-
+    const verses         = passage.verses();
+    const segments       = passage.segments();
     const initialReducer = passageReducer(undefined, {});
 
-    expect(initialReducer.activeVerse).toEqual(0);
-    expect(initialReducer.totalVerses).toEqual(verses.length);
+    expect(initialReducer.active[constants.VERSE_MODE]).toEqual(0);
+    expect(initialReducer.active[constants.SEGMENT_MODE]).toEqual(0);
+    expect(initialReducer.active[constants.CHAPTER_MODE]).toEqual('1');
     expect(initialReducer.verses).toEqual(verses);
-    expect(initialReducer.mode).toEqual(constants.MULTI_MODE);
+    expect(initialReducer.mode).toEqual(constants.SEGMENT_MODE);
+    expect(initialReducer.recallStage).toEqual(constants.RECALL_STAGES.FULL);
+    expect(initialReducer.isAudioPlaying).toEqual(false);
   });
 
-  it('should handle the NEXT_VERSE action', () => {
-    const initialReducer = passageReducer(undefined, {
-      type: constants.NEXT_VERSE
-    });
+  describe('navigating between content in modes', () => {
+    describe('verse mode', () => {
+      let initialState = {};
 
-    expect(initialReducer.activeVerse).toEqual(1);
-
-    const secondReducer = passageReducer(initialReducer, {
-      type: constants.NEXT_VERSE
-    });
-
-    expect(secondReducer.activeVerse).toEqual(2);
-  });
-
-  // Test that it handles changing the project name correctly
-  it('should handle the PREVIOUS_VERSE action', () => {
-    const initialState = {
-      activeVerse: 6
-    };
-
-    const initialReducer = passageReducer(initialState, {
-      type: constants.PREVIOUS_VERSE
-    });
-
-    expect(initialReducer.activeVerse).toEqual(5);
-
-    const secondReducer = passageReducer(initialReducer, {
-      type: constants.PREVIOUS_VERSE
-    });
-
-    expect(secondReducer.activeVerse).toEqual(4);
-  });
-
-  describe('enabling READ', () => {
-    it('should be able to set verseState for individual verses', () => {
-      const initialState = {
-        verses: [
-          {
-            text: 'First',
-            verseState: VERSE_STATES.RECALL
-          }, {
-            text: 'Second',
-            verseState: VERSE_STATES.RECALL
-          }
-        ]
-      };
-
-      const initialReducer = passageReducer(initialState, {
-        type: constants.ENABLE_READ,
-        index: 1
+      beforeEach(() => {
+        initialState = {
+          active: {
+            'VERSE_MODE': 5
+          },
+          lowerBound : 5,
+          upperBound : 5,
+          mode       : constants.VERSE_MODE
+        };
       });
 
-      expect(initialReducer.verses[0].verseState).toEqual(VERSE_STATES.RECALL);
-      expect(initialReducer.verses[1].verseState).toEqual(VERSE_STATES.READ);
-    });
-  });
+      it('should increment both bounds by one on next', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: constants.NAVIGATE_NEXT
+        });
 
-  describe('enabling RECALL', () => {
-    it('should be able to set verseState for individual verses', () => {
-      const initialState = {
-        verses: [
-          {
-            text: 'First',
-            verseState: VERSE_STATES.READ
-          }, {
-            text: 'Second',
-            verseState: VERSE_STATES.READ
-          }
-        ]
-      };
+        expect(initialReducer.lowerBound).toEqual(6);
+        expect(initialReducer.upperBound).toEqual(6);
+        expect(initialReducer.active[constants.VERSE_MODE]).toEqual(6);
 
-      const initialReducer = passageReducer(initialState, {
-        type: constants.ENABLE_RECALL,
-        index: 1
+        let secondReducer = passageReducer(initialReducer, {
+          type: constants.NAVIGATE_NEXT
+        });
+
+        expect(secondReducer.lowerBound).toEqual(7);
+        expect(secondReducer.upperBound).toEqual(7);
+        expect(secondReducer.active[constants.VERSE_MODE]).toEqual(7);
       });
 
-      expect(initialReducer.verses[0].verseState).toEqual(VERSE_STATES.READ);
-      expect(initialReducer.verses[1].verseState).toEqual(VERSE_STATES.RECALL);
+      it('should decrement both bounds by one on next', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: constants.NAVIGATE_PREVIOUS
+        });
+
+        expect(initialReducer.lowerBound).toEqual(4);
+        expect(initialReducer.upperBound).toEqual(4);
+        expect(initialReducer.active[constants.VERSE_MODE]).toEqual(4);
+
+        let secondReducer = passageReducer(initialReducer, {
+          type: constants.NAVIGATE_PREVIOUS
+        });
+
+        expect(secondReducer.lowerBound).toEqual(3);
+        expect(secondReducer.upperBound).toEqual(3);
+        expect(secondReducer.active[constants.VERSE_MODE]).toEqual(3);
+      });
     });
-  });
 
-  describe('enabling LISTEN', () => {
-    it('should be able to set isAudioPlaying for individual verses', () => {
-      const initialState = {
-        verses: [
-          {
-            text: 'First',
-            verseState: VERSE_STATES.READ
-          }, {
-            text: 'Second',
-            verseState: VERSE_STATES.READ
-          }
-        ]
-      };
+    describe('segment mode', () => {
+      let initialState = {};
 
-      const initialReducer = passageReducer(initialState, {
-        type: constants.PLAY_AUDIO,
-        index: 1
+      beforeEach(() => {
+        initialState = {
+          active: {
+            'SEGMENT_MODE': 5
+          },
+          lowerBound : 5,
+          upperBound : 5,
+          mode       : constants.SEGMENT_MODE
+        };
       });
 
-      expect(initialReducer.verses[0].isAudioPlaying).toBeFalsy();
-      expect(initialReducer.verses[1].verseState).toBeTruthy();
+      it('should increment both bounds by one on next', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: constants.NAVIGATE_NEXT
+        });
+
+        expect(initialReducer.lowerBound).toEqual(6);
+        expect(initialReducer.upperBound).toEqual(6);
+        expect(initialReducer.active[constants.SEGMENT_MODE]).toEqual(6);
+
+        let secondReducer = passageReducer(initialReducer, {
+          type: constants.NAVIGATE_NEXT
+        });
+
+        expect(secondReducer.lowerBound).toEqual(7);
+        expect(secondReducer.upperBound).toEqual(7);
+        expect(secondReducer.active[constants.SEGMENT_MODE]).toEqual(7);
+      });
+
+      it('should decrement both bounds by one on next', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: constants.NAVIGATE_PREVIOUS
+        });
+
+        expect(initialReducer.lowerBound).toEqual(4);
+        expect(initialReducer.upperBound).toEqual(4);
+        expect(initialReducer.active[constants.SEGMENT_MODE]).toEqual(4);
+
+        let secondReducer = passageReducer(initialReducer, {
+          type: constants.NAVIGATE_PREVIOUS
+        });
+
+        expect(secondReducer.lowerBound).toEqual(3);
+        expect(secondReducer.upperBound).toEqual(3);
+        expect(secondReducer.active[constants.SEGMENT_MODE]).toEqual(3);
+      });
+    });
+
+    describe('chapter mode', () => {
+      let initialState = {};
+
+      beforeEach(() => {
+        initialState = {
+          active: {
+            'CHAPTER_MODE': 5
+          },
+          lowerBound : 5,
+          upperBound : 5,
+          mode       : constants.CHAPTER_MODE
+        };
+      });
+
+      it('should increment both bounds by one on next', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: constants.NAVIGATE_NEXT
+        });
+
+        expect(initialReducer.lowerBound).toEqual(6);
+        expect(initialReducer.upperBound).toEqual(6);
+        expect(initialReducer.active[constants.CHAPTER_MODE]).toEqual(6);
+
+        let secondReducer = passageReducer(initialReducer, {
+          type: constants.NAVIGATE_NEXT
+        });
+
+        expect(secondReducer.lowerBound).toEqual(7);
+        expect(secondReducer.upperBound).toEqual(7);
+        expect(secondReducer.active[constants.CHAPTER_MODE]).toEqual(7);
+      });
+
+      it('should decrement both bounds by one on next', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: constants.NAVIGATE_PREVIOUS
+        });
+
+        expect(initialReducer.lowerBound).toEqual(4);
+        expect(initialReducer.upperBound).toEqual(4);
+        expect(initialReducer.active[constants.CHAPTER_MODE]).toEqual(4);
+
+        let secondReducer = passageReducer(initialReducer, {
+          type: constants.NAVIGATE_PREVIOUS
+        });
+
+        expect(secondReducer.lowerBound).toEqual(3);
+        expect(secondReducer.upperBound).toEqual(3);
+        expect(secondReducer.active[constants.CHAPTER_MODE]).toEqual(3);
+      });
     });
   });
 
-  it('should handle the CHANGE_MODE action', () => {
-    const initialReducer = passageReducer(undefined, {
-      type: constants.CHANGE_MODE,
-      mode: constants.MULTI_MODE
+  describe('changing modes', () => {
+    describe('verse mode', () => {
+      let initialState = {};
+
+      beforeEach(() => {
+        initialState = {
+          active: {
+            'VERSE_MODE': 0
+          },
+          lowerBound : 5,
+          upperBound : 5
+        };
+      });
+
+      it('should handle the CHANGE_MODE action', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: constants.CHANGE_MODE,
+          mode: constants.VERSE_MODE
+        });
+
+        expect(initialReducer.mode).toEqual(constants.VERSE_MODE);
+      });
+
+      it('should set the bounds based on the active element', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: constants.CHANGE_MODE,
+          mode: constants.VERSE_MODE
+        });
+
+        expect(initialReducer.lowerBound).toEqual(0);
+        expect(initialReducer.upperBound).toEqual(0);
+      });
     });
 
-    expect(initialReducer.mode).toEqual(constants.MULTI_MODE);
+    describe('segment mode', () => {
+      it('should handle the CHANGE_MODE action', () => {
+        let initialReducer = passageReducer(undefined, {
+          type: constants.CHANGE_MODE,
+          mode: constants.SEGMENT_MODE
+        });
+
+        expect(initialReducer.mode).toEqual(constants.SEGMENT_MODE);
+      });
+
+      // this can be tested one we have static segments in place
+      it('should set the bounds based on the active element', () => {
+
+      });
+    });
+
+    describe('chapter mode', () => {
+      let initialState = {};
+
+      beforeEach(() => {
+        initialState = {
+          active: {
+            'CHAPTER_MODE': '1'
+          },
+          lowerBound : 5,
+          upperBound : 5
+        };
+      });
+
+      it('should handle the CHANGE_MODE action', () => {
+        let initialReducer = passageReducer(undefined, {
+          type: constants.CHANGE_MODE,
+          mode: constants.CHAPTER_MODE
+        });
+
+        expect(initialReducer.mode).toEqual(constants.CHAPTER_MODE);
+      });
+
+      it('should set the bounds based on the active element', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: constants.CHANGE_MODE,
+          mode: constants.CHAPTER_MODE
+        });
+
+        expect(initialReducer.lowerBound).toEqual(passage.chapters()['1'].lower);
+        expect(initialReducer.upperBound).toEqual(passage.chapters()['1'].upper);
+      });
+    });
   });
 });

--- a/test/reducer.passage.test.js
+++ b/test/reducer.passage.test.js
@@ -73,15 +73,16 @@ describe('passageReducer', () => {
     });
 
     describe('segment mode', () => {
-      let initialState = {};
+      let initialState   = {},
+          staticSegments = passage.staticSegments();
 
       beforeEach(() => {
         initialState = {
           active: {
             'SEGMENT_MODE': 5
           },
-          lowerBound : 5,
-          upperBound : 5,
+          lowerBound : staticSegments[5].lower,
+          upperBound : staticSegments[5].upper,
           mode       : constants.SEGMENT_MODE
         };
       });
@@ -91,16 +92,16 @@ describe('passageReducer', () => {
           type: constants.NAVIGATE_NEXT
         });
 
-        expect(initialReducer.lowerBound).toEqual(6);
-        expect(initialReducer.upperBound).toEqual(6);
+        expect(initialReducer.lowerBound).toEqual(staticSegments[6].lower);
+        expect(initialReducer.upperBound).toEqual(staticSegments[6].upper);
         expect(initialReducer.active[constants.SEGMENT_MODE]).toEqual(6);
 
         let secondReducer = passageReducer(initialReducer, {
           type: constants.NAVIGATE_NEXT
         });
 
-        expect(secondReducer.lowerBound).toEqual(7);
-        expect(secondReducer.upperBound).toEqual(7);
+        expect(secondReducer.lowerBound).toEqual(staticSegments[7].lower);
+        expect(secondReducer.upperBound).toEqual(staticSegments[7].upper);
         expect(secondReducer.active[constants.SEGMENT_MODE]).toEqual(7);
       });
 
@@ -109,16 +110,16 @@ describe('passageReducer', () => {
           type: constants.NAVIGATE_PREVIOUS
         });
 
-        expect(initialReducer.lowerBound).toEqual(4);
-        expect(initialReducer.upperBound).toEqual(4);
+        expect(initialReducer.lowerBound).toEqual(staticSegments[4].lower);
+        expect(initialReducer.upperBound).toEqual(staticSegments[4].upper);
         expect(initialReducer.active[constants.SEGMENT_MODE]).toEqual(4);
 
         let secondReducer = passageReducer(initialReducer, {
           type: constants.NAVIGATE_PREVIOUS
         });
 
-        expect(secondReducer.lowerBound).toEqual(3);
-        expect(secondReducer.upperBound).toEqual(3);
+        expect(secondReducer.lowerBound).toEqual(staticSegments[3].lower);
+        expect(secondReducer.upperBound).toEqual(staticSegments[3].upper);
         expect(secondReducer.active[constants.SEGMENT_MODE]).toEqual(3);
       });
     });
@@ -129,10 +130,10 @@ describe('passageReducer', () => {
       beforeEach(() => {
         initialState = {
           active: {
-            'CHAPTER_MODE': 5
+            'CHAPTER_MODE': '2'
           },
-          lowerBound : 5,
-          upperBound : 5,
+          lowerBound : passage.chapters()['2'].lower,
+          upperBound : passage.chapters()['2'].upper,
           mode       : constants.CHAPTER_MODE
         };
       });
@@ -142,17 +143,9 @@ describe('passageReducer', () => {
           type: constants.NAVIGATE_NEXT
         });
 
-        expect(initialReducer.lowerBound).toEqual(6);
-        expect(initialReducer.upperBound).toEqual(6);
-        expect(initialReducer.active[constants.CHAPTER_MODE]).toEqual(6);
-
-        let secondReducer = passageReducer(initialReducer, {
-          type: constants.NAVIGATE_NEXT
-        });
-
-        expect(secondReducer.lowerBound).toEqual(7);
-        expect(secondReducer.upperBound).toEqual(7);
-        expect(secondReducer.active[constants.CHAPTER_MODE]).toEqual(7);
+        expect(initialReducer.lowerBound).toEqual(passage.chapters()['3'].lower);
+        expect(initialReducer.upperBound).toEqual(passage.chapters()['3'].upper);
+        expect(initialReducer.active[constants.CHAPTER_MODE].toString()).toEqual('3');
       });
 
       it('should decrement both bounds by one on next', () => {
@@ -160,17 +153,9 @@ describe('passageReducer', () => {
           type: constants.NAVIGATE_PREVIOUS
         });
 
-        expect(initialReducer.lowerBound).toEqual(4);
-        expect(initialReducer.upperBound).toEqual(4);
-        expect(initialReducer.active[constants.CHAPTER_MODE]).toEqual(4);
-
-        let secondReducer = passageReducer(initialReducer, {
-          type: constants.NAVIGATE_PREVIOUS
-        });
-
-        expect(secondReducer.lowerBound).toEqual(3);
-        expect(secondReducer.upperBound).toEqual(3);
-        expect(secondReducer.active[constants.CHAPTER_MODE]).toEqual(3);
+        expect(initialReducer.lowerBound).toEqual(passage.chapters()['1'].lower);
+        expect(initialReducer.upperBound).toEqual(passage.chapters()['1'].upper);
+        expect(initialReducer.active[constants.CHAPTER_MODE].toString()).toEqual('1');
       });
     });
   });
@@ -210,6 +195,18 @@ describe('passageReducer', () => {
     });
 
     describe('segment mode', () => {
+      let initialState = {};
+
+      beforeEach(() => {
+        initialState = {
+          active: {
+            'SEGMENT_MODE': 5
+          },
+          lowerBound : 5,
+          upperBound : 5
+        };
+      });
+
       it('should handle the CHANGE_MODE action', () => {
         let initialReducer = passageReducer(undefined, {
           type: constants.CHANGE_MODE,
@@ -219,9 +216,14 @@ describe('passageReducer', () => {
         expect(initialReducer.mode).toEqual(constants.SEGMENT_MODE);
       });
 
-      // this can be tested one we have static segments in place
       it('should set the bounds based on the active element', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: constants.CHANGE_MODE,
+          mode: constants.SEGMENT_MODE
+        });
 
+        expect(initialReducer.lowerBound).toEqual(passage.staticSegments()[5].lower);
+        expect(initialReducer.upperBound).toEqual(passage.staticSegments()[5].upper);
       });
     });
 


### PR DESCRIPTION
I know there are going to be several people working on the app throughout the week, so I wanted to get this major refactor in before then so everyone can be on a much better starting base after the changes we discussed today.

This PR includes:
- The three modes (verse, segment, chapter)
- The three recall stages (full, first, none)
- Removal of the verse 'card' concept, which:
  - Moves the the recall and audio buttons to the main ui
  - Allows for a more expandable `renderText()` function
- Meta generation for the top navigation (which, as far as I can tell, works great with the audio)
- Navigation based on upper and lower bounds (so we don't have to duplicate passage data), including rendering of verses based on those bounds... this makes changing verses easier

Things NOT in this PR:
- I didn't do any sort of css audit after moving this stuff around... it's just too late at night
- There is no detection of when you can or can't navigate forward or backward (but there are placeholders)
- There is no 'smart' navigation through the modes based on your active verse... not sure how we want to define that yet
- The segments are randomly generated on app start, I didn't look for the segmentation data to enter into the app
- I'm not happy with how chapters are being tracked (as an object with the key being the chapter number), but I was trying to think of something that would allow easier navigation in the future... I honestly might just make it an array like everything else
- The line wrapping is weird with the 'none' mode

If anyone (and I mean anyone at all) has an issue with the direction this is establishing for navigation (and tracking active verses and the like) in the app, please speak up. This is something that (while I know we did sort of pivot today) really needs to be locked down so we can keep moving forward.

As always, hit me up with questions if you have any.

Closes #7 because of the large refactor.
