### PR TITLE
Build chapters dynamically

### DIFF
--- a/js/passage.js
+++ b/js/passage.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 export class Passage {
   constructor(verses) {
     this._verses = verses;
@@ -110,15 +112,17 @@ export function segments() {
 }
 
 export function chapters() {
-  const chapterIndexes = [
-    [0,  23], // 1:1-23
-    [23, 22], // 2:1-22
-    [45, 21]  // 3:1-21
-  ];
+  let _chapters = {};
+  let key = '';
 
-  return chapterIndexes.map((touple) => {
-    return new Passage(rawVerses.slice(touple[0], (touple[0] + touple[1])));
+  rawVerses.forEach((verse) => {
+    key = verse.book + verse.chapter
+
+    if (!_chapters[key]) { _chapters[key] = []; }
+
+    _chapters[key].push(verse);
   });
+  return _.map(_chapters, (verses) => { return new Passage(verses) });
 }
 
 const rawVerses = Object.freeze([

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "fontfaceobserver": "^1.5.1",
     "history": "1.17.0",
+    "lodash": "^4.5.0",
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
     "react-redux": "^4.0.0",

--- a/test/passage.test.js
+++ b/test/passage.test.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import { Passage } from '../js/passage'
+import { Passage, chapters } from '../js/passage'
 
 const oneVerse = Object.freeze([
   {
@@ -118,6 +118,15 @@ describe('Passage', () => {
       expect(new Passage(twoVerses).recallNoneText()).toEqual(
         '<sup>1</sup>    ,            <sup>2</sup>                          .'
       );
+    });
+  });
+
+  describe('chapters()', () => {
+    it('breaks things into 3 chapters', () => {
+      expect(chapters().length).toEqual(3);
+      expect(chapters()[0].metadata()).toEqual('Ephesians 1:1-23');
+      expect(chapters()[1].metadata()).toEqual('Ephesians 2:1-22');
+      expect(chapters()[2].metadata()).toEqual('Ephesians 3:1-21');
     });
   });
 });


### PR DESCRIPTION
Refactoring split up chapters dynamically.  Brought in the lodash dependency as I wanted an easy to map over values, which I couldn't seem to find in native ES2015.  Would be open to other alternatives.
