### PR TITLE
Passage Switcher

### DIFF
--- a/js/actions/AppActions.js
+++ b/js/actions/AppActions.js
@@ -26,7 +26,7 @@
 // Disable the no-use-before-define eslint rule for this file
 // It makes more sense to have the asnyc actions before the non-async ones
 /* eslint-disable no-use-before-define */
-import { NAVIGATE_NEXT, NAVIGATE_PREVIOUS, CHANGE_MODE, CHANGE_RECALL, PLAY_AUDIO, PAUSE_AUDIO, RESTORE_STATE } from '../constants/AppConstants';
+import { NAVIGATE_NEXT, NAVIGATE_PREVIOUS, NAVIGATE_INDEX, CHANGE_MODE, CHANGE_RECALL, PLAY_AUDIO, PAUSE_AUDIO, RESTORE_STATE } from '../constants/AppConstants';
 
 export function asyncNavigateNext() {
   return (dispatch) => {
@@ -52,6 +52,19 @@ export function asyncNavigatePrevious() {
 
 export function navigatePrevious() {
   return { type: NAVIGATE_PREVIOUS };
+}
+
+export function asyncNavigateIndex(index) {
+  return (dispatch) => {
+    // You can do async stuff here!
+    // API fetching, Animations,...
+    // For more information as to how and why you would do this, check https://github.com/gaearon/redux-thunk
+    return dispatch(navigateIndex(index));
+  };
+}
+
+export function navigateIndex(index) {
+  return { type: NAVIGATE_INDEX, index };
 }
 
 export function asyncChangeMode(mode) {

--- a/js/components/PassageSelect.react.js
+++ b/js/components/PassageSelect.react.js
@@ -1,0 +1,34 @@
+/*
+ * PassageSelect
+ */
+import React, { Component } from 'react';
+import { asyncNavigateIndex } from '../actions/AppActions';
+
+class PassageSelect extends Component {
+  renderOption(passage, index, selected) {
+    return (
+      <option
+        key={ index }
+        value={ index }
+      >{ passage.metadata() }</option>
+    )
+  }
+
+  changePassage(e) {
+    this.props.dispatch(asyncNavigateIndex(parseInt(e.target.value)));
+  }
+
+  render() {
+    return (
+      <select
+        ref="passage-select"
+        value={ this.props.selectedIndex }
+        onChange={ this.changePassage.bind(this) }
+      >
+        { this.props.collection.map((passage, index) => { return this.renderOption(passage, index, this.props.selectedIndex) }) }
+      </select>
+    )
+  }
+}
+
+export default PassageSelect

--- a/js/components/pages/PassagePage.react.js
+++ b/js/components/pages/PassagePage.react.js
@@ -9,6 +9,7 @@ import { asyncNavigateNext, asyncNavigatePrevious, asyncChangeMode, asyncChangeR
 import { VERSE_MODE, SEGMENT_MODE, CHAPTER_MODE, RECALL_STAGES } from '../../constants/AppConstants';
 
 import AudioPlayer from '../AudioPlayer.react';
+import PassageSelect from '../PassageSelect.react';
 import Swipeable from 'react-swipeable';
 
 // use named export for unconnected component (unit tests)
@@ -39,14 +40,20 @@ export class PassagePage extends Component {
       return true;
     }
 
-    let activePassage = {}
+    let activePassage = {};
+    let activeCollection = [];
+    let activeIndex = 0;
     if (mode === VERSE_MODE) {
-      activePassage = verses[active[VERSE_MODE]];
+      activeCollection = verses;
+      activeIndex = active[VERSE_MODE];
     } else if (mode === SEGMENT_MODE) {
-      activePassage = segments[active[SEGMENT_MODE]];
+      activeCollection = segments;
+      activeIndex = active[SEGMENT_MODE];
     } else {
-      activePassage = chapters[active[CHAPTER_MODE]];
+      activeCollection = chapters;
+      activeIndex = active[CHAPTER_MODE];
     }
+    activePassage = activeCollection[activeIndex];
 
     return (
       <div>
@@ -69,7 +76,11 @@ export class PassagePage extends Component {
           </div>
 
           <div className="meta-information">
-            { activePassage.metadata() }
+            <PassageSelect
+              dispatch={dispatch}
+              collection={activeCollection}
+              selectedIndex={activeIndex}
+            ></PassageSelect>
           </div>
         </div>
 

--- a/js/constants/AppConstants.js
+++ b/js/constants/AppConstants.js
@@ -8,6 +8,7 @@
  */
 export const NAVIGATE_PREVIOUS = 'NAVIGATE_PREVIOUS';
 export const NAVIGATE_NEXT     = 'NAVIGATE_NEXT';
+export const NAVIGATE_INDEX    = 'NAVIGATE_INDEX';
 
 export const PLAY_AUDIO  = 'PLAY_AUDIO';
 export const PAUSE_AUDIO = 'PAUSE_AUDIO';

--- a/js/reducers/passageReducer.js
+++ b/js/reducers/passageReducer.js
@@ -42,32 +42,37 @@ const initialState = assignToEmpty({
   isAudioPlaying: false
 });
 
+function assignAndSave(oldState, newState) {
+  let state = assignToEmpty(oldState, newState)
+  saveState(state);
+  return state;
+}
+
+function activeCollection(state) {
+  if (state.mode === VERSE_MODE) {
+    return verses;
+  } else if (state.mode === SEGMENT_MODE) {
+    return segments;
+  } else {
+    return chapters;
+  }
+}
+
 function passageReducer(state = initialState, action) {
   Object.freeze(state); // Don't mutate state directly, always use assign()!
 
   let newActive = {};
-  let activeCollection = [];
-  let newState;
 
   switch (action.type) {
     case NAVIGATE_NEXT:
       newActive = state.active;
-      if (state.mode === VERSE_MODE) {
-        activeCollection = verses;
-      } else if (state.mode === SEGMENT_MODE) {
-        activeCollection = segments;
-      } else {
-        activeCollection = chapters;
-      }
-      if (newActive[state.mode] < activeCollection.length - 1) {
+      if (newActive[state.mode] < activeCollection(state).length - 1) {
         newActive[state.mode]++;
       }
 
-      newState = assignToEmpty(state, {
+      return assignAndSave(state, {
         active: newActive
       });
-      saveState(newState);
-      return newState;
 
     case NAVIGATE_PREVIOUS:
       newActive = state.active;
@@ -75,45 +80,30 @@ function passageReducer(state = initialState, action) {
         newActive[state.mode]--;
       }
 
-      newState = assignToEmpty(state, {
+      return assignAndSave(state, {
         active: newActive
       });
-      saveState(newState);
-      return newState;
 
     case NAVIGATE_INDEX:
       newActive = state.active;
-      if (state.mode === VERSE_MODE) {
-        activeCollection = verses;
-      } else if (state.mode === SEGMENT_MODE) {
-        activeCollection = segments;
-      } else {
-        activeCollection = chapters;
-      }
 
-      if (activeCollection[action.index]) {
+      if (activeCollection(state)[action.index]) {
         newActive[state.mode] = action.index;
       }
 
-      newState = assignToEmpty(state, {
+      return assignAndSave(state, {
         active: newActive
       });
-      saveState(newState);
-      return newState;
 
     case CHANGE_RECALL:
-      newState = assignToEmpty(state, {
+      return assignAndSave(state, {
         recallStage: action.mode
       });
-      saveState(newState);
-      return newState;
 
     case CHANGE_MODE:
-      newState = assignToEmpty(state, {
+      return assignAndSave(state, {
         mode: action.mode
       });
-      saveState(newState);
-      return newState;
 
     case PLAY_AUDIO:
       return assignToEmpty(state, {

--- a/js/reducers/passageReducer.js
+++ b/js/reducers/passageReducer.js
@@ -14,7 +14,7 @@
  */
 import assignToEmpty from '../utils/assign';
 
-import { NAVIGATE_NEXT, NAVIGATE_PREVIOUS, CHANGE_RECALL, PLAY_AUDIO, PAUSE_AUDIO, RECALL_STAGES } from '../constants/AppConstants';
+import { NAVIGATE_NEXT, NAVIGATE_PREVIOUS, NAVIGATE_INDEX, CHANGE_RECALL, PLAY_AUDIO, PAUSE_AUDIO, RECALL_STAGES } from '../constants/AppConstants';
 import { VERSE_MODE, SEGMENT_MODE, CHAPTER_MODE, CHANGE_MODE, RESTORE_STATE } from '../constants/AppConstants';
 import { saveState } from '../saveState'
 import * as passage from '../passage'
@@ -73,6 +73,26 @@ function passageReducer(state = initialState, action) {
       newActive = state.active;
       if (newActive[state.mode] > 0) {
         newActive[state.mode]--;
+      }
+
+      newState = assignToEmpty(state, {
+        active: newActive
+      });
+      saveState(newState);
+      return newState;
+
+    case NAVIGATE_INDEX:
+      newActive = state.active;
+      if (state.mode === VERSE_MODE) {
+        activeCollection = verses;
+      } else if (state.mode === SEGMENT_MODE) {
+        activeCollection = segments;
+      } else {
+        activeCollection = chapters;
+      }
+
+      if (activeCollection[action.index]) {
+        newActive[state.mode] = action.index;
       }
 
       newState = assignToEmpty(state, {

--- a/test/reducer.passage.test.js
+++ b/test/reducer.passage.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 
-import { VERSE_MODE, SEGMENT_MODE, CHAPTER_MODE, CHANGE_RECALL, RECALL_STAGES, CHANGE_MODE, NAVIGATE_NEXT, NAVIGATE_PREVIOUS, PLAY_AUDIO, RESTORE_STATE } from '../js/constants/AppConstants';
+import { VERSE_MODE, SEGMENT_MODE, CHAPTER_MODE, CHANGE_RECALL, RECALL_STAGES, CHANGE_MODE, NAVIGATE_NEXT, NAVIGATE_PREVIOUS, NAVIGATE_INDEX, PLAY_AUDIO, RESTORE_STATE } from '../js/constants/AppConstants';
 import * as passage from '../js/passage'
 import { getLastState, clearSavedTestState } from '../js/saveState'
 
@@ -68,6 +68,26 @@ describe('passageReducer', () => {
 
         expect(secondReducer.active[VERSE_MODE]).toEqual(3);
       });
+
+      it('should navigate to index', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: NAVIGATE_INDEX, index: 2
+        });
+
+        expect(initialReducer.active[VERSE_MODE]).toEqual(2);
+        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
+        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+      });
+
+      it('should ignore invalid index', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: NAVIGATE_INDEX, index: 1000
+        });
+
+        expect(initialReducer.active[VERSE_MODE]).toEqual(5);
+        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
+        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+      });
     });
 
     describe('segment mode', () => {
@@ -115,6 +135,26 @@ describe('passageReducer', () => {
 
         expect(secondReducer.active[SEGMENT_MODE]).toEqual(3);
       });
+
+      it('should navigate to index', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: NAVIGATE_INDEX, index: 2
+        });
+
+        expect(initialReducer.active[SEGMENT_MODE]).toEqual(2);
+        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
+        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+      });
+
+      it('should ignore invalid index', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: NAVIGATE_INDEX, index: 1000
+        });
+
+        expect(initialReducer.active[SEGMENT_MODE]).toEqual(5);
+        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
+        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+      });
     });
 
     describe('chapter mode', () => {
@@ -147,6 +187,26 @@ describe('passageReducer', () => {
         });
 
         expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
+        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
+      });
+
+      it('should navigate to index', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: NAVIGATE_INDEX, index: 2
+        });
+
+        expect(initialReducer.active[CHAPTER_MODE]).toEqual(2);
+        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
+        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
+      });
+
+      it('should ignore invalid index', () => {
+        let initialReducer = passageReducer(initialState, {
+          type: NAVIGATE_INDEX, index: 1000
+        });
+
+        expect(initialReducer.active[CHAPTER_MODE]).toEqual(1);
         expect(initialReducer.active[VERSE_MODE]).toEqual(0);
         expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
       });

--- a/test/reducer.passage.test.js
+++ b/test/reducer.passage.test.js
@@ -11,15 +11,15 @@ describe('passageReducer', () => {
     const verses         = passage.verses();
     const segments       = passage.segments();
     const chapters       = passage.chapters();
-    const initialReducer = passageReducer(undefined, {});
+    const intialReduction = passageReducer(undefined, {});
 
-    expect(initialReducer.active[VERSE_MODE]).toEqual(0);
-    expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
-    expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
-    expect(initialReducer.verses).toEqual(verses);
-    expect(initialReducer.mode).toEqual(SEGMENT_MODE);
-    expect(initialReducer.recallStage).toEqual(RECALL_STAGES.FULL);
-    expect(initialReducer.isAudioPlaying).toEqual(false);
+    expect(intialReduction.active[VERSE_MODE]).toEqual(0);
+    expect(intialReduction.active[SEGMENT_MODE]).toEqual(0);
+    expect(intialReduction.active[CHAPTER_MODE]).toEqual(0);
+    expect(intialReduction.verses).toEqual(verses);
+    expect(intialReduction.mode).toEqual(SEGMENT_MODE);
+    expect(intialReduction.recallStage).toEqual(RECALL_STAGES.FULL);
+    expect(intialReduction.isAudioPlaying).toEqual(false);
   });
 
   describe('navigating between content in modes', () => {
@@ -38,55 +38,55 @@ describe('passageReducer', () => {
       });
 
       it('should increment active by one', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_NEXT
         });
 
-        expect(initialReducer.active[VERSE_MODE]).toEqual(6);
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(6);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(0);
 
-        let secondReducer = passageReducer(initialReducer, {
+        let secondReduction = passageReducer(intialReduction, {
           type: NAVIGATE_NEXT
         });
 
-        expect(secondReducer.active[VERSE_MODE]).toEqual(7);
+        expect(secondReduction.active[VERSE_MODE]).toEqual(7);
       });
 
       it('should decrement active by one', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_PREVIOUS
         });
 
-        expect(initialReducer.active[VERSE_MODE]).toEqual(4);
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(4);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(0);
 
-        let secondReducer = passageReducer(initialReducer, {
+        let secondReduction = passageReducer(intialReduction, {
           type: NAVIGATE_PREVIOUS
         });
 
-        expect(secondReducer.active[VERSE_MODE]).toEqual(3);
+        expect(secondReduction.active[VERSE_MODE]).toEqual(3);
       });
 
       it('should navigate to index', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_INDEX, index: 2
         });
 
-        expect(initialReducer.active[VERSE_MODE]).toEqual(2);
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(2);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(0);
       });
 
       it('should ignore invalid index', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_INDEX, index: 1000
         });
 
-        expect(initialReducer.active[VERSE_MODE]).toEqual(5);
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(5);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(0);
       });
     });
 
@@ -105,55 +105,55 @@ describe('passageReducer', () => {
       });
 
       it('should increment active by one', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_NEXT
         });
 
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(6);
-        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(6);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(0);
 
-        let secondReducer = passageReducer(initialReducer, {
+        let secondReduction = passageReducer(intialReduction, {
           type: NAVIGATE_NEXT
         });
 
-        expect(secondReducer.active[SEGMENT_MODE]).toEqual(7);
+        expect(secondReduction.active[SEGMENT_MODE]).toEqual(7);
       });
 
       it('should decrement active by one', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_PREVIOUS
         });
 
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(4);
-        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(4);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(0);
 
-        let secondReducer = passageReducer(initialReducer, {
+        let secondReduction = passageReducer(intialReduction, {
           type: NAVIGATE_PREVIOUS
         });
 
-        expect(secondReducer.active[SEGMENT_MODE]).toEqual(3);
+        expect(secondReduction.active[SEGMENT_MODE]).toEqual(3);
       });
 
       it('should navigate to index', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_INDEX, index: 2
         });
 
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(2);
-        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(2);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(0);
       });
 
       it('should ignore invalid index', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_INDEX, index: 1000
         });
 
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(5);
-        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(5);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(0);
       });
     });
 
@@ -172,69 +172,69 @@ describe('passageReducer', () => {
       });
 
       it('should increment active by one', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_NEXT
         });
 
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(2);
-        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(2);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(0);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(0);
       });
 
       it('should decrement active by one', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_PREVIOUS
         });
 
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
-        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(0);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(0);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(0);
       });
 
       it('should navigate to index', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_INDEX, index: 2
         });
 
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(2);
-        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(2);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(0);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(0);
       });
 
       it('should ignore invalid index', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_INDEX, index: 1000
         });
 
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(1);
-        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(1);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(0);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(0);
       });
 
       it('should handle navigating below lower bounds', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_PREVIOUS
         });
-        let secondReducer = passageReducer(initialState, {
+        let secondReduction = passageReducer(initialState, {
           type: NAVIGATE_PREVIOUS
         });
 
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(0);
-        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(0);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(0);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(0);
       })
 
       it('should handle navigating above upper bounds', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: NAVIGATE_NEXT
         });
-        let secondReducer = passageReducer(initialState, {
+        let secondReduction = passageReducer(initialState, {
           type: NAVIGATE_NEXT
         });
 
-        expect(initialReducer.active[CHAPTER_MODE]).toEqual(2);
-        expect(initialReducer.active[VERSE_MODE]).toEqual(0);
-        expect(initialReducer.active[SEGMENT_MODE]).toEqual(0);
+        expect(intialReduction.active[CHAPTER_MODE]).toEqual(2);
+        expect(intialReduction.active[VERSE_MODE]).toEqual(0);
+        expect(intialReduction.active[SEGMENT_MODE]).toEqual(0);
       })
     });
   });
@@ -255,12 +255,12 @@ describe('passageReducer', () => {
       });
 
       it('should handle the CHANGE_MODE action', () => {
-        let initialReducer = passageReducer(initialState, {
+        let intialReduction = passageReducer(initialState, {
           type: CHANGE_MODE,
           mode: VERSE_MODE
         });
 
-        expect(initialReducer.mode).toEqual(VERSE_MODE);
+        expect(intialReduction.mode).toEqual(VERSE_MODE);
       });
     });
 
@@ -279,12 +279,12 @@ describe('passageReducer', () => {
       });
 
       it('should handle the CHANGE_MODE action', () => {
-        let initialReducer = passageReducer(undefined, {
+        let intialReduction = passageReducer(undefined, {
           type: CHANGE_MODE,
           mode: SEGMENT_MODE
         });
 
-        expect(initialReducer.mode).toEqual(SEGMENT_MODE);
+        expect(intialReduction.mode).toEqual(SEGMENT_MODE);
       });
     });
 
@@ -303,12 +303,12 @@ describe('passageReducer', () => {
       });
 
       it('should handle the CHANGE_MODE action', () => {
-        let initialReducer = passageReducer(undefined, {
+        let intialReduction = passageReducer(undefined, {
           type: CHANGE_MODE,
           mode: CHAPTER_MODE
         });
 
-        expect(initialReducer.mode).toEqual(CHAPTER_MODE);
+        expect(intialReduction.mode).toEqual(CHAPTER_MODE);
       });
     });
   });


### PR DESCRIPTION
Adds a control to switch passages by index.  Also includes a refactoring to the passageReducer to remove some duplication.

![passage_navigate_by_index](https://cloud.githubusercontent.com/assets/640501/13203714/be2900f4-d88b-11e5-956d-261bb033ed03.gif)

The other navigation feature I was going to look at is changing the active index for the other modes as you navigate but want to keep that a separate PR.
