### PR TITLE
Fix mobile audio

### DIFF
--- a/js/actions/AppActions.js
+++ b/js/actions/AppActions.js
@@ -93,11 +93,12 @@ export function changeRecall(mode) {
   return { type: CHANGE_RECALL, mode };
 }
 
-export function asyncPlayAudio() {
+export function asyncPlayAudio(audioElement) {
   return (dispatch) => {
     // You can do async stuff here!
     // API fetching, Animations,...
     // For more information as to how and why you would do this, check https://github.com/gaearon/redux-thunk
+    audioElement.play();
     return dispatch(playAudio());
   }
 }
@@ -106,11 +107,12 @@ export function playAudio() {
   return { type: PLAY_AUDIO };
 }
 
-export function asyncPauseAudio() {
+export function asyncPauseAudio(audioElement) {
   return (dispatch) => {
     // You can do async stuff here!
     // API fetching, Animations,...
     // For more information as to how and why you would do this, check https://github.com/gaearon/redux-thunk
+    audioElement.pause();
     return dispatch(pauseAudio());
   }
 }

--- a/js/components/AudioPlayer.react.js
+++ b/js/components/AudioPlayer.react.js
@@ -7,26 +7,53 @@ import { connect } from 'react-redux';
 import { asyncPlayAudio, asyncPauseAudio } from '../actions/AppActions';
 
 class AudioPlayer extends Component {
-  render() {
-    const { dispatch, src, isAudioPlaying } = this.props;
 
-    if (isAudioPlaying) {
-      return (
-        <span className="audioContainer">
-          <button className="pauseAudio" onClick={() => {dispatch(asyncPauseAudio())} }>
-            <i className="fa fa-pause" title="pause"></i>
-          </button>
-          <audio src={ src } autoPlay="autoPlay" loop="loop"/>
-        </span>
-      );
-    } else {
-      return (
-        <span className="audioContainer">
-          <button className="playAudio" onClick={() => {dispatch(asyncPlayAudio())} }>
-            <i className="fa fa-play" title="play"></i>
-          </button>
-        </span>
-      );
+  renderPlayButton() {
+    const { dispatch } = this.props;
+    this._audioElement = null;
+    return (
+      <button className="playAudio" onClick={() => {dispatch(asyncPlayAudio());}}>
+        <i className="fa fa-play" title="play"></i>
+      </button>
+    );
+  }
+
+  renderPauseButtonAndAudio() {
+    const { dispatch } = this.props;
+    return (
+      <span>
+        <button className="pauseAudio" onClick={() => {dispatch(asyncPauseAudio())}}>
+          <i className="fa fa-pause" title="pause"></i>
+        </button>
+        { this.renderAudioElement() }
+      </span>
+    );
+  }
+
+  renderAudioElement() {
+    const { src } = this.props;
+    return (
+      <audio ref={(me) => {this._audioElement = me}} loop="loop">
+        <source src={ src } type="audio/mp3"/>
+      </audio>
+    );
+  }
+
+  render() {
+    const { isAudioPlaying } = this.props;
+    return (
+      <span className="audioContainer">
+        { isAudioPlaying ? this.renderPauseButtonAndAudio() : this.renderPlayButton() }
+      </span>
+    )
+  }
+
+  componentDidUpdate() {
+    if (this.props.isAudioPlaying) {
+      // Call load in case we change verses while the audio is playing
+      // Or else the audio element will keep using the old src
+      this._audioElement.load();
+      this._audioElement.play();
     }
   }
 }

--- a/js/components/AudioPlayer.react.js
+++ b/js/components/AudioPlayer.react.js
@@ -12,21 +12,18 @@ class AudioPlayer extends Component {
     const { dispatch } = this.props;
     this._audioElement = null;
     return (
-      <button className="playAudio" onClick={() => {dispatch(asyncPlayAudio());}}>
+      <button className="playAudio" onClick={() => {dispatch(asyncPlayAudio(this._audioElement));}}>
         <i className="fa fa-play" title="play"></i>
       </button>
     );
   }
 
-  renderPauseButtonAndAudio() {
+  renderPauseButton() {
     const { dispatch } = this.props;
     return (
-      <span>
-        <button className="pauseAudio" onClick={() => {dispatch(asyncPauseAudio())}}>
-          <i className="fa fa-pause" title="pause"></i>
-        </button>
-        { this.renderAudioElement() }
-      </span>
+      <button className="pauseAudio" onClick={() => {dispatch(asyncPauseAudio(this._audioElement))}}>
+        <i className="fa fa-pause" title="pause"></i>
+      </button>
     );
   }
 
@@ -43,7 +40,8 @@ class AudioPlayer extends Component {
     const { isAudioPlaying } = this.props;
     return (
       <span className="audioContainer">
-        { isAudioPlaying ? this.renderPauseButtonAndAudio() : this.renderPlayButton() }
+        { isAudioPlaying ? this.renderPauseButton() : this.renderPlayButton() }
+        { this.renderAudioElement() }
       </span>
     )
   }


### PR DESCRIPTION
The root issue was that in iOS, audio elements cannot autoplay, and the
play method must be called during a user interaction event.
