### PR TITLE
Task 44 mobile tweaks

### DIFF
--- a/css/components/_passage.css
+++ b/css/components/_passage.css
@@ -110,7 +110,8 @@
 }
 
 .verse-wrapper {
-  margin: 0 10% 7em 10%;
+  margin: 0 10%;
+  padding-bottom: 7em;
 
   &.recallFirstText {
     .char:not(:first-of-type) {

--- a/js/app.js
+++ b/js/app.js
@@ -12,6 +12,10 @@ import 'file?name=[name].[ext]!../serviceworker.js';
 import 'file?name=[name].[ext]!../manifest.json';
 import 'file?name=[name].[ext]!../.htaccess';
 
+// Handle 300ms click delay on mobile
+import FastClick from 'fastclick';
+FastClick.attach(document.body);
+
 // Check for ServiceWorker support before trying to install it
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('/serviceworker.js').then(() => {

--- a/js/passage.js
+++ b/js/passage.js
@@ -46,7 +46,7 @@ export class Passage {
   formattedText() {
     return this._verses.map(function (rawVerse) {
       return '<sup>' + rawVerse.verse + '</sup>' + spannifyText(rawVerse.text);
-    }).join('');
+    }).join('<span class="word"> </span>');
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "App used to memorize Ephesians 1-3 for Vintage Church, Raleigh, NC",
   "dependencies": {
     "combokeys": "^2.4.4",
+    "fastclick": "^1.0.6",
     "history": "1.17.0",
     "lodash": "^4.5.0",
     "react": "^0.14.2",

--- a/test/passage.test.js
+++ b/test/passage.test.js
@@ -6,7 +6,7 @@ const oneVerse = Object.freeze([
     "book": "Ephesians",
     "chapter": 1,
     "verse": 1,
-    "text": "Text, of verse 1 "
+    "text": "Text, of verse 1"
   }
 ]);
 const twoVerses = Object.freeze([
@@ -14,7 +14,7 @@ const twoVerses = Object.freeze([
     "book": "Ephesians",
     "chapter": 1,
     "verse": 1,
-    "text": "Text, of verse 1 "
+    "text": "Text, of verse 1"
   },
   {
     "book": "Ephesians",
@@ -28,7 +28,7 @@ const crossChapterVerses = Object.freeze([
     "book": "Ephesians",
     "chapter": 1,
     "verse": 1,
-    "text": "Text, of verse 1 "
+    "text": "Text, of verse 1"
   },
   {
     "book": "Ephesians",
@@ -125,8 +125,8 @@ describe('Passage', () => {
         '<span class="word">' +
           '<span class="char">o</span>' +
           '<span class="char">f</span>' +
-        '</span>' + 
-        '<span class="word"> </span>' + 
+        '</span>' +
+        '<span class="word"> </span>' +
         '<span class="word">' +
           '<span class="char">v</span>' +
           '<span class="char">e</span>' +
@@ -135,8 +135,7 @@ describe('Passage', () => {
           '<span class="char">e</span>' +
         '</span>' +
         '<span class="word"> </span>' +
-        '<span class="word">1</span>' +
-        '<span class="word"> </span>');
+        '<span class="word">1</span>');
     });
 
     it('multiple verses', () => {
@@ -152,8 +151,8 @@ describe('Passage', () => {
         '<span class="word">' +
           '<span class="char">o</span>' +
           '<span class="char">f</span>' +
-        '</span>' + 
-        '<span class="word"> </span>' + 
+        '</span>' +
+        '<span class="word"> </span>' +
         '<span class="word">' +
           '<span class="char">v</span>' +
           '<span class="char">e</span>' +
@@ -193,7 +192,7 @@ describe('Passage', () => {
           '<span class="char">i</span>' +
           '<span class="char">k</span>' +
           '<span class="char">e</span>' +
-        '</span>' + 
+        '</span>' +
         '<span class="word"> </span>' +
         '<span class="word">' +
           '<span class="char">t</span>' +


### PR DESCRIPTION
Increase swipe area. By converting margin to padding that space below the text can be used as a swipe area. Otherwise you have to swipe on the text content.

Add FastClick to handle 300ms mobile click delay

No visual changes.
