### PR TITLE
Missing word mode

### DIFF
--- a/css/components/_passage.css
+++ b/css/components/_passage.css
@@ -120,6 +120,12 @@
     }
   }
 
+  &.recallWords {
+    .word:not(:nth-child(3n+2)) {
+      color: $transparent;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+    }
+  }
 }
 
 .reciteMode {

--- a/js/components/pages/PassagePage.react.js
+++ b/js/components/pages/PassagePage.react.js
@@ -153,17 +153,34 @@ export class PassagePage extends Component {
           <button
             className={ recallStage == RECALL_STAGES.FULL ? "active" : ""}
             onClick={() => { dispatch(asyncChangeRecall(RECALL_STAGES.FULL)) }}
-          >KNOW</button>
+          >
+            KNOW<br />
+            LIVE
+          </button>
+
+          <button
+            className={ recallStage == RECALL_STAGES.WORDS ? "active" : ""}
+            onClick={() => { dispatch(asyncChangeRecall(RECALL_STAGES.WORDS)) }}
+          >
+            KNOW<br />
+            ____
+          </button>
 
           <button
             className={ recallStage == RECALL_STAGES.FIRST ? "active" : ""}
             onClick={() => { dispatch(asyncChangeRecall(RECALL_STAGES.FIRST)) }}
-          >K___</button>
+          >
+            K___<br />
+            L___
+          </button>
 
           <button
             className={ recallStage == RECALL_STAGES.NONE ? "active" : ""}
             onClick={() => { dispatch(asyncChangeRecall(RECALL_STAGES.NONE)) }}
-          >____</button>
+          >
+            ____<br />
+            ____
+          </button>
 
           <AudioPlayer className="audio-controls"
                        src={ activePassage.audioUrl() }

--- a/js/constants/AppConstants.js
+++ b/js/constants/AppConstants.js
@@ -22,6 +22,7 @@ export const CHAPTER_MODE = 'CHAPTER_MODE';
 export const CHANGE_RECALL = 'CHANGE_RECALL';
 export const RECALL_STAGES = {
   FULL : 'readText',
+  WORDS: 'recallWords',
   FIRST: 'recallFirstText',
   NONE : 'recallNoneText'
 };

--- a/js/passage.js
+++ b/js/passage.js
@@ -46,14 +46,18 @@ export class Passage {
   formattedText() {
     return this._verses.map(function (rawVerse) {
       return '<sup>' + rawVerse.verse + '</sup>' + spannifyText(rawVerse.text);
-    }).join('<span class="word"> </span>');
+    }).join('<span class="space"> </span>');
   }
 }
 
 function spannifyText(text) {
   return text.split(/\b/).map((word) => {
     let spannifiedWord = word.replace(/([A-Za-z])/g, '<span class="char">$1</span>');
-    return '<span class="word">' + spannifiedWord + '</span>';
+    let className = 'word';
+    if (spannifiedWord.match(/^\s|\.|\,\s|\,$/)) {
+      className = 'space';
+    }
+    return '<span class="' + className + '">' + spannifiedWord + '</span>';
   }).join('');
 }
 

--- a/test/passage.test.js
+++ b/test/passage.test.js
@@ -121,12 +121,12 @@ describe('Passage', () => {
           '<span class="char">x</span>' +
           '<span class="char">t</span>' +
         '</span>' +
-        '<span class="word">, </span>' +
+        '<span class="space">, </span>' +
         '<span class="word">' +
           '<span class="char">o</span>' +
           '<span class="char">f</span>' +
         '</span>' +
-        '<span class="word"> </span>' +
+        '<span class="space"> </span>' +
         '<span class="word">' +
           '<span class="char">v</span>' +
           '<span class="char">e</span>' +
@@ -134,7 +134,7 @@ describe('Passage', () => {
           '<span class="char">s</span>' +
           '<span class="char">e</span>' +
         '</span>' +
-        '<span class="word"> </span>' +
+        '<span class="space"> </span>' +
         '<span class="word">1</span>');
     });
 
@@ -147,12 +147,12 @@ describe('Passage', () => {
           '<span class="char">x</span>' +
           '<span class="char">t</span>' +
         '</span>' +
-        '<span class="word">, </span>' +
+        '<span class="space">, </span>' +
         '<span class="word">' +
           '<span class="char">o</span>' +
           '<span class="char">f</span>' +
         '</span>' +
-        '<span class="word"> </span>' +
+        '<span class="space"> </span>' +
         '<span class="word">' +
           '<span class="char">v</span>' +
           '<span class="char">e</span>' +
@@ -160,16 +160,16 @@ describe('Passage', () => {
           '<span class="char">s</span>' +
           '<span class="char">e</span>' +
         '</span>' +
-        '<span class="word"> </span>' +
+        '<span class="space"> </span>' +
         '<span class="word">1</span>' +
-        '<span class="word"> </span>' +
+        '<span class="space"> </span>' +
         '<sup>2</sup>' +
         '<span class="word">' +
           '<span class="char">a</span>' +
           '<span class="char">n</span>' +
           '<span class="char">d</span>' +
         '</span>' +
-        '<span class="word"> </span>' +
+        '<span class="space"> </span>' +
         '<span class="word">' +
           '<span class="char">v</span>' +
           '<span class="char">e</span>' +
@@ -177,30 +177,30 @@ describe('Passage', () => {
           '<span class="char">s</span>' +
           '<span class="char">e</span>' +
         '</span>' +
-        '<span class="word"> </span>' +
+        '<span class="space"> </span>' +
         '<span class="word">2</span>' +
-        '<span class="word"> </span>' +
+        '<span class="space"> </span>' +
         '<span class="word">' +
           '<span class="char">e</span>' +
           '<span class="char">n</span>' +
           '<span class="char">d</span>' +
           '<span class="char">s</span>' +
         '</span>' +
-        '<span class="word"> </span>' +
+        '<span class="space"> </span>' +
         '<span class="word">' +
           '<span class="char">l</span>' +
           '<span class="char">i</span>' +
           '<span class="char">k</span>' +
           '<span class="char">e</span>' +
         '</span>' +
-        '<span class="word"> </span>' +
+        '<span class="space"> </span>' +
         '<span class="word">' +
           '<span class="char">t</span>' +
           '<span class="char">h</span>' +
           '<span class="char">i</span>' +
           '<span class="char">s</span>' +
         '</span>' +
-        '<span class="word">.</span>');
+        '<span class="space">.</span>');
     });
   });
 


### PR DESCRIPTION
After planning around with the first segment again tonight with all the fixes, wanted to put together a simple missing words mode as it does seem to be a leap from reading to recalling by just first letter.

No urgency on getting this merge before Sunday.  Also, I'd be open to ideas of how to structure button if we added this new mode.

This also doesn't use any kind of algorithm to generate random missing words.  Instead is uses the every N algorithms that [:nth-child](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child) supports.

![missing_words](https://cloud.githubusercontent.com/assets/640501/13551924/220259b8-e318-11e5-9453-6980aaf4bf67.gif)
